### PR TITLE
Round temperature to one decimal to fit on screen

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ class MainWindow(QObject):
             if await self.connectedClient.is_connected():
                 currentTemp = await self.connectedClient.read_gatt_char(CURRENT_TEMP)
                 CurrentDegree = float(int.from_bytes(currentTemp, byteorder='little', signed=False)) * 0.01
+                CurrentDegree = round(CurrentDegree, 1)
                 print(CurrentDegree)
                 # Send UI Signal
                 self.getDegree.emit(float(CurrentDegree))


### PR DESCRIPTION
Some temperatures were shown with floating point rounding, causing them to overfill the screen with zeros. This is a online change to round the temperature before printing.

For example: 58.90000000000000004 is now 58.9